### PR TITLE
Metrics

### DIFF
--- a/internal/metrics/metrics_gitsync.go
+++ b/internal/metrics/metrics_gitsync.go
@@ -1,0 +1,48 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	GitSyncFailed = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ocp_git_sync_failed_total",
+			Help: "Total number of failed Git sync operations",
+		},
+		[]string{"source"},
+	)
+
+	GitSyncCount = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "ocp_git_sync_count_total",
+			Help: "Total number of Git sync operations",
+		},
+	)
+
+	GitSyncDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "ocp_git_sync_duration_seconds",
+			Help:    "Git sync duration in seconds",
+			Buckets: []float64{0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.5, 2, 5, 10, 30, 60},
+		},
+		[]string{"source", "repo"},
+	)
+
+	LastGitSyncStart = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "ocp_last_git_sync_start_timestamp",
+			Help: "Unix timestamp of when the last git sync started",
+		},
+		[]string{"source", "repo"},
+	)
+
+	LastGitSyncEnd = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "ocp_last_git_sync_end_timestamp",
+			Help: "Unix timestamp of when the last git sync ended",
+		},
+		[]string{"source", "repo"},
+	)
+)

--- a/internal/metrics/metrics_worker.go
+++ b/internal/metrics/metrics_worker.go
@@ -1,0 +1,48 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	BundleBuildFailed = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ocp_bundle_build_failed",
+			Help: "Number of times a bundle has failed to build",
+		},
+		[]string{"bundle", "error_type"},
+	)
+
+	BundleBuildCount = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "ocp_bundle_build_count",
+			Help: "Total number of times a bundle has been built",
+		},
+	)
+
+	BundleBuildDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "ocp_bundle_build_duration_seconds",
+			Help:    "Bundle build duration in seconds",
+			Buckets: []float64{0.1, 0.2, 0.5, 1, 1.5, 2, 5, 10, 30, 60},
+		},
+		[]string{"bundle"},
+	)
+
+	LastBundleBuildStart = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "ocp_last_bundle_build_start_timestamp",
+			Help: "Unix timestamp of when the last bundle build started",
+		},
+		[]string{"bundle"},
+	)
+
+	LastBundleBuildEnd = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "ocp_last_bundle_build_end_timestamp",
+			Help: "Unix timestamp of when the last bundle build ended",
+		},
+		[]string{"bundle"},
+	)
+)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/open-policy-agent/opa/v1/server/writer"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/styrainc/opa-control-plane/internal/config"
 	"github.com/styrainc/opa-control-plane/internal/database"
@@ -33,6 +34,7 @@ func (s *Server) Init() *Server {
 		s.router = http.NewServeMux()
 	}
 
+	s.router.Handle("GET    /metrics", promhttp.Handler())
 	s.router.HandleFunc("GET    /health", s.health)
 	s.router.HandleFunc("GET    /v1/sources/{source}/data/{path...}", authenticationMiddleware(s.db, s.v1SourcesDataGet))
 	s.router.HandleFunc("POST   /v1/sources/{source}/data/{path...}", authenticationMiddleware(s.db, s.v1SourcesDataPut))


### PR DESCRIPTION
Eksempel:

```
# HELP ocp_bundle_build_count Total number of times a bundle has been built
# TYPE ocp_bundle_build_count counter
ocp_bundle_build_count 12
# HELP ocp_bundle_build_duration_seconds Bundle build duration in seconds
# TYPE ocp_bundle_build_duration_seconds histogram
ocp_bundle_build_duration_seconds_bucket{bundle="jwt-library-example-git-source-bundle-app-1",le="0.1"} 0
ocp_bundle_build_duration_seconds_bucket{bundle="jwt-library-example-git-source-bundle-app-1",le="0.2"} 0
ocp_bundle_build_duration_seconds_bucket{bundle="jwt-library-example-git-source-bundle-app-1",le="0.5"} 0
ocp_bundle_build_duration_seconds_bucket{bundle="jwt-library-example-git-source-bundle-app-1",le="1"} 5
ocp_bundle_build_duration_seconds_bucket{bundle="jwt-library-example-git-source-bundle-app-1",le="1.5"} 5
ocp_bundle_build_duration_seconds_bucket{bundle="jwt-library-example-git-source-bundle-app-1",le="2"} 6
ocp_bundle_build_duration_seconds_bucket{bundle="jwt-library-example-git-source-bundle-app-1",le="5"} 6
ocp_bundle_build_duration_seconds_bucket{bundle="jwt-library-example-git-source-bundle-app-1",le="10"} 6
ocp_bundle_build_duration_seconds_bucket{bundle="jwt-library-example-git-source-bundle-app-1",le="30"} 6
ocp_bundle_build_duration_seconds_bucket{bundle="jwt-library-example-git-source-bundle-app-1",le="60"} 6
ocp_bundle_build_duration_seconds_bucket{bundle="jwt-library-example-git-source-bundle-app-1",le="+Inf"} 6
ocp_bundle_build_duration_seconds_sum{bundle="jwt-library-example-git-source-bundle-app-1"} 5.388272005000001
ocp_bundle_build_duration_seconds_count{bundle="jwt-library-example-git-source-bundle-app-1"} 6
ocp_bundle_build_duration_seconds_bucket{bundle="jwt-library-example-git-source-bundle-minio",le="0.1"} 0
ocp_bundle_build_duration_seconds_bucket{bundle="jwt-library-example-git-source-bundle-minio",le="0.2"} 0
ocp_bundle_build_duration_seconds_bucket{bundle="jwt-library-example-git-source-bundle-minio",le="0.5"} 0
ocp_bundle_build_duration_seconds_bucket{bundle="jwt-library-example-git-source-bundle-minio",le="1"} 0
ocp_bundle_build_duration_seconds_bucket{bundle="jwt-library-example-git-source-bundle-minio",le="1.5"} 0
ocp_bundle_build_duration_seconds_bucket{bundle="jwt-library-example-git-source-bundle-minio",le="2"} 1
ocp_bundle_build_duration_seconds_bucket{bundle="jwt-library-example-git-source-bundle-minio",le="5"} 6
ocp_bundle_build_duration_seconds_bucket{bundle="jwt-library-example-git-source-bundle-minio",le="10"} 6
ocp_bundle_build_duration_seconds_bucket{bundle="jwt-library-example-git-source-bundle-minio",le="30"} 6
ocp_bundle_build_duration_seconds_bucket{bundle="jwt-library-example-git-source-bundle-minio",le="60"} 6
ocp_bundle_build_duration_seconds_bucket{bundle="jwt-library-example-git-source-bundle-minio",le="+Inf"} 6
ocp_bundle_build_duration_seconds_sum{bundle="jwt-library-example-git-source-bundle-minio"} 13.573483607
ocp_bundle_build_duration_seconds_count{bundle="jwt-library-example-git-source-bundle-minio"} 6
# HELP ocp_bundle_build_failed Number of times a bundle has failed to build
# TYPE ocp_bundle_build_failed counter
ocp_bundle_build_failed{bundle="jwt-library-example-git-source-bundle-minio",error_type="PUSH_FAILED"} 6
# HELP ocp_git_sync_count_total Total number of Git sync operations
# TYPE ocp_git_sync_count_total counter
ocp_git_sync_count_total 24
# HELP ocp_git_sync_duration_seconds Git sync duration in seconds
# TYPE ocp_git_sync_duration_seconds histogram
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-example-jwt.git",source="jwt-library-example-git-source-app",le="0.1"} 0
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-example-jwt.git",source="jwt-library-example-git-source-app",le="0.2"} 1
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-example-jwt.git",source="jwt-library-example-git-source-app",le="0.3"} 10
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-example-jwt.git",source="jwt-library-example-git-source-app",le="0.4"} 10
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-example-jwt.git",source="jwt-library-example-git-source-app",le="0.5"} 10
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-example-jwt.git",source="jwt-library-example-git-source-app",le="0.6"} 10
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-example-jwt.git",source="jwt-library-example-git-source-app",le="0.7"} 10
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-example-jwt.git",source="jwt-library-example-git-source-app",le="0.8"} 11
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-example-jwt.git",source="jwt-library-example-git-source-app",le="0.9"} 12
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-example-jwt.git",source="jwt-library-example-git-source-app",le="1"} 12
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-example-jwt.git",source="jwt-library-example-git-source-app",le="1.5"} 12
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-example-jwt.git",source="jwt-library-example-git-source-app",le="2"} 12
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-example-jwt.git",source="jwt-library-example-git-source-app",le="5"} 12
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-example-jwt.git",source="jwt-library-example-git-source-app",le="10"} 12
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-example-jwt.git",source="jwt-library-example-git-source-app",le="30"} 12
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-example-jwt.git",source="jwt-library-example-git-source-app",le="60"} 12
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-example-jwt.git",source="jwt-library-example-git-source-app",le="+Inf"} 12
ocp_git_sync_duration_seconds_sum{repo="https://github.com/bd-b0100/pol-styra-library-example-jwt.git",source="jwt-library-example-git-source-app"} 3.983277611
ocp_git_sync_duration_seconds_count{repo="https://github.com/bd-b0100/pol-styra-library-example-jwt.git",source="jwt-library-example-git-source-app"} 12
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-jwt.git",source="jwt_v2-app",le="0.1"} 0
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-jwt.git",source="jwt_v2-app",le="0.2"} 0
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-jwt.git",source="jwt_v2-app",le="0.3"} 8
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-jwt.git",source="jwt_v2-app",le="0.4"} 10
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-jwt.git",source="jwt_v2-app",le="0.5"} 11
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-jwt.git",source="jwt_v2-app",le="0.6"} 12
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-jwt.git",source="jwt_v2-app",le="0.7"} 12
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-jwt.git",source="jwt_v2-app",le="0.8"} 12
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-jwt.git",source="jwt_v2-app",le="0.9"} 12
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-jwt.git",source="jwt_v2-app",le="1"} 12
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-jwt.git",source="jwt_v2-app",le="1.5"} 12
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-jwt.git",source="jwt_v2-app",le="2"} 12
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-jwt.git",source="jwt_v2-app",le="5"} 12
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-jwt.git",source="jwt_v2-app",le="10"} 12
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-jwt.git",source="jwt_v2-app",le="30"} 12
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-jwt.git",source="jwt_v2-app",le="60"} 12
ocp_git_sync_duration_seconds_bucket{repo="https://github.com/bd-b0100/pol-styra-library-jwt.git",source="jwt_v2-app",le="+Inf"} 12
ocp_git_sync_duration_seconds_sum{repo="https://github.com/bd-b0100/pol-styra-library-jwt.git",source="jwt_v2-app"} 3.679482266
ocp_git_sync_duration_seconds_count{repo="https://github.com/bd-b0100/pol-styra-library-jwt.git",source="jwt_v2-app"} 12
# HELP ocp_last_bundle_build_end_timestamp Unix timestamp of when the last bundle build ended
# TYPE ocp_last_bundle_build_end_timestamp gauge
ocp_last_bundle_build_end_timestamp{bundle="jwt-library-example-git-source-bundle-app-1"} 1.759234889e+09
ocp_last_bundle_build_end_timestamp{bundle="jwt-library-example-git-source-bundle-minio"} 1.759234897e+09
# HELP ocp_last_bundle_build_start_timestamp Unix timestamp of when the last bundle build started
# TYPE ocp_last_bundle_build_start_timestamp gauge
ocp_last_bundle_build_start_timestamp{bundle="jwt-library-example-git-source-bundle-app-1"} 1.759234888e+09
ocp_last_bundle_build_start_timestamp{bundle="jwt-library-example-git-source-bundle-minio"} 1.759234895e+09
# HELP ocp_last_git_sync_end_timestamp Unix timestamp of when the last git sync ended
# TYPE ocp_last_git_sync_end_timestamp gauge
ocp_last_git_sync_end_timestamp{repo="https://github.com/bd-b0100/pol-styra-library-example-jwt.git",source="jwt-library-example-git-source-app"} 1.759234895e+09
ocp_last_git_sync_end_timestamp{repo="https://github.com/bd-b0100/pol-styra-library-jwt.git",source="jwt_v2-app"} 1.759234896e+09
# HELP ocp_last_git_sync_start_timestamp Unix timestamp of when the last git sync started
# TYPE ocp_last_git_sync_start_timestamp gauge
ocp_last_git_sync_start_timestamp{repo="https://github.com/bd-b0100/pol-styra-library-example-jwt.git",source="jwt-library-example-git-source-app"} 1.759234895e+09
ocp_last_git_sync_start_timestamp{repo="https://github.com/bd-b0100/pol-styra-library-jwt.git",source="jwt_v2-app"} 1.759234895e+09
```